### PR TITLE
Hotfix CVE-2026-31431

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -407,7 +407,7 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "surface"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "surface"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Maximilian Luz <luzmaximilian@gmail.com>"]
 description = "Control various aspects of Microsoft Surface devices on Linux from the Command-Line"
 

--- a/etc/modprobe.d/surface-debian-disable-algif.conf
+++ b/etc/modprobe.d/surface-debian-disable-algif.conf
@@ -1,0 +1,2 @@
+# https://askubuntu.com/a/1566257/1004020
+install algif_aead /bin/false

--- a/pkg/bin/makebin
+++ b/pkg/bin/makebin
@@ -72,6 +72,9 @@ package() {
     mkdir -p "$pkgdir/usr/lib/systemd/system/suspend.target.wants"
     ln -sT "../surface-rapl.service" "$pkgdir/usr/lib/systemd/system/suspend.target.wants/surface-rapl.service"
 
+    # hotfixes
+    install -D -m644 "etc/modprobe.d/surface-debian-disable-algif.conf" "$pkgdir/etc/modprobe.d/surface-debian-disable-algif.conf"
+
     # copy license
     install -D -m644 "LICENSE" "$pkgdir/LICENSE"
 

--- a/pkg/deb/debian/changelog
+++ b/pkg/deb/debian/changelog
@@ -1,3 +1,9 @@
+surface-control (0.5.1-1) unstable; urgency=medium
+
+  * Hotfix kernel CVE-2026-31431
+
+ -- Daniel Tang <danielzgtg.opensource@gmail.com>  Thu, 30 Apr 2026 04:32:59 -0400
+
 surface-control (0.5.0-1) unstable; urgency=medium
 
   * Add systemd service to disable Intel RAPL PL4 on resume

--- a/pkg/deb/debian/rules
+++ b/pkg/deb/debian/rules
@@ -28,5 +28,7 @@ override_dh_install:
 	mkdir -p "${pkgdir}/usr/lib/systemd/system/suspend.target.wants"
 	ln -sT "../surface-rapl.service" "${pkgdir}/usr/lib/systemd/system/suspend.target.wants/surface-rapl.service"
 
+	# hotfixes
+	install -D -m644 "etc/modprobe.d/surface-debian-disable-algif.conf" "${pkgdir}/etc/modprobe.d/surface-debian-disable-algif.conf"
 %:
 	dh $@


### PR DESCRIPTION
I'm hotfixing this in surface-control because the kernel builds haven't been working for weeks.

This hotfixes an escalation-to-root kernel vulnerability.

Apparently Fedora has it built into the kernel, so this modprobe hotfix  won't work. A GRUB `initcall_blacklist=algif_aead_init` is needed.

Fixes: https://github.com/linux-surface/linux-surface/issues/2090